### PR TITLE
(maint) skip network verify test due to RO-4153

### DIFF
--- a/molecule/default/tests/test_verify_networks_created.py
+++ b/molecule/default/tests/test_verify_networks_created.py
@@ -1,5 +1,4 @@
 import os
-import re
 import pytest
 import testinfra.utils.ansible_runner
 
@@ -16,6 +15,7 @@ pre_cmd = "bash -c \"source /root/openrc; "
 
 
 @pytest.mark.jira('asc-239')
+@pytest.mark.skip(reason='untestable until RO-4153 is fixed')
 def test_verify_network_list(host):
     """Verify the neutron network was created"""
     cmd = pre_cmd + "openstack network list\""
@@ -25,6 +25,7 @@ def test_verify_network_list(host):
 
 
 @pytest.mark.jira('asc-239')
+@pytest.mark.skip(reason='untestable until RO-4153 is fixed')
 def test_verify_subnet_list(host):
     """Verify the neutron subnet was created """
     cmd = pre_cmd + "openstack subnet list\""


### PR DESCRIPTION
Failure to create network on deployed RPCO has been taking too much time to investigate and significantly slow down the test case creating progress. 

This PR to skip the test that verify if networks have been created properly
The tests will be reactivated (by a future PR)  when bug ticket RO-4153 is resolved.