### PR TITLE
ASC-623 Update Linter Config for Multiple Jira Args

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,9 @@
 [flake8]
 ignore = E501
-pytest_mark1 = name=test_id,value_match=uuid
-pytest_mark2 = name=jira,regex_match=[a-zA-Z]+-\d+
-filename_check1 = filter_regex=test_.+,filename_regex=test_[\w-]+$
+pytest_mark1 = name=test_id
+               value_match=uuid
+pytest_mark2 = name=jira
+               regex_match=[a-zA-Z]+-\d+
+               allow_multiple_args=true
+filename_check1 = filter_regex=test_.+
+                  filename_regex=test_[\w-]+$


### PR DESCRIPTION
This change enables automation engineers to specify multiple Jira tickets as
arguments to the "jira" pytest mark. Also, I updated the formatting of the
config file to be more readable.