### PR TITLE
ASC-755 Enforce that All "test_id" Marks are Unique

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 ignore = E501
 pytest_mark1 = name=test_id
                value_match=uuid
+               enforce_unique_value=true
 pytest_mark2 = name=jira
                regex_match=[a-zA-Z]+-\d+
                allow_multiple_args=true


### PR DESCRIPTION
Update the flake8 config to enforce unique values for the "test_id" pytest
mark.