### PR TITLE
ASC-1035 Ensure authorized key on containers

### DIFF
--- a/ssh_key_containers.yml
+++ b/ssh_key_containers.yml
@@ -1,0 +1,9 @@
+---
+- name: Get all containers
+  shell: |
+    lxc-ls -1
+  register: containers
+- name: Add authorized key on containers
+  shell: |
+    lxc-attach -n "{{ item }}" -- bash -c 'echo "{{ public_key }}" >> /root/.ssh/authorized_keys'
+  with_items: "{{ containers.stdout_lines }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,8 @@
     - rpc_openstack is undefined or
       rpc_openstack['rpc_product_release'] is undefined
 
+- import_tasks: ssh_key_containers.yml
+
 - block:
     - import_tasks: cloning_openstack_ansible_ops.yml
     - import_tasks: create_virtualenv_on_sut.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for molecule-validate-neutron-deploy
+public_key: "{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"


### PR DESCRIPTION
This commit adds a task to ensure that the ssh key for root on localhost
is added to the containers on the target host. Prior to this commit, running
the molecule converge step failed when the MNAIO environment was
deployed from pre-existing images. This is because the deploy hosts key
is propagated to the VMs in the environment but not the containers.